### PR TITLE
remove quote parameter from facebook url due to deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,6 @@ Twitter will inherit `og:title`, `og:description` and `og:image` tags by default
 | Parameter | Type   | Required | Notes                             |
 | --------- | ------ | -------- | --------------------------------- |
 | url       | string | **Yes**  | URL of shared webpage.            |
-| quote     | string | No       | Quote to show in Facebook card.   |
 | hashtag   | string | No       | Hashtag to show in Facebook card. |
 
 Basic component example usage:

--- a/src/utils/getFacebookUrl.ts
+++ b/src/utils/getFacebookUrl.ts
@@ -2,23 +2,18 @@ import { BaseShareProps } from "../types";
 import objectToUrlParams from "./objectToUrlParams";
 
 export interface FacebookProps extends BaseShareProps {
-  /** Quote to show in Facebook card. */
-  quote?: string;
-
   /** Hashtag to show in Facebook card. */
   hashtag?: string;
 }
 
 export const getFacebookUrl = ({
   url,
-  quote,
   hashtag: suppliedHashtag,
 }: FacebookProps) => {
   let hashtag = suppliedHashtag;
   if (hashtag && hashtag.charAt(0) !== "#") hashtag = `#${hashtag}`;
   return `https://www.facebook.com/sharer/sharer.php${objectToUrlParams({
     u: url,
-    quote,
     hashtag,
   })}`;
 };

--- a/src/utils/getShareUrl.ts
+++ b/src/utils/getShareUrl.ts
@@ -13,7 +13,6 @@ export const getShareUrl = (
   socialPlatform: SocialPlatforms,
   {
     url,
-    quote,
     hashtag,
     title,
     summary,
@@ -25,7 +24,7 @@ export const getShareUrl = (
 ) => {
   switch (socialPlatform) {
     case SocialPlatforms.Facebook:
-      return getFacebookUrl({ url, quote, hashtag });
+      return getFacebookUrl({ url, hashtag });
 
     case SocialPlatforms.Linkedin:
       return getLinkedinUrl({ url, title, summary, source });


### PR DESCRIPTION
proof of deprecation: https://developers.facebook.com/support/bugs/734680371318112/?comment_id=743056360480513